### PR TITLE
Added Window Title on Windows

### DIFF
--- a/src/common/active_window.rs
+++ b/src/common/active_window.rs
@@ -2,6 +2,7 @@ use super::window_position::WindowPosition;
 
 #[derive(Debug)]
 pub struct ActiveWindow {
+    pub title: String,
     pub window_id: String,
     pub process_id: u64,
     pub position: WindowPosition

--- a/src/linux/platform_api.rs
+++ b/src/linux/platform_api.rs
@@ -106,6 +106,7 @@ impl PlatformApi for LinuxPlatformApi {
             process_id: window_pid.try_into().unwrap(),
             window_id: active_window.resource_id().to_string(),
             position,
+            title: String::from(""),
         })
     }
 }

--- a/src/mac/platform_api.rs
+++ b/src/mac/platform_api.rs
@@ -81,7 +81,8 @@ impl PlatformApi for MacPlatformApi {
                     let active_window = ActiveWindow {
                         window_id: window_id.to_string(),
                         process_id: active_window_pid as u64,
-                        position: win_pos
+                        position: win_pos,
+                        title: String::from(""),
                     };
 
                     return Ok(active_window)


### PR DESCRIPTION
I have added functionality to get the window title on Windows. Unfortunately, I do not have a Linux or Mac machine set up to do the same for those.

I am not too up to date on the Rust best practices but L28 seems like a possible race condition to me as the window handle is retrieved again inside the self.get_position() call.