### PR TITLE
Fixed process id mismatch for windows

### DIFF
--- a/src/win/platform_api.rs
+++ b/src/win/platform_api.rs
@@ -28,9 +28,9 @@ impl PlatformApi for WindowsPlatformApi {
         let win_position = get_foreground_window_position(active_window)?;
         let active_window_position = WindowPosition::from_win_rect(&win_position);
         let active_window_title = get_window_title(active_window)?;
-        let lpdw_process_id = unsafe {
-            let pid_ptr: *mut u32 = std::mem::zeroed();
-            GetWindowThreadProcessId(active_window, pid_ptr)
+        let mut lpdw_process_id: u32 = 0;
+        unsafe {
+            GetWindowThreadProcessId(active_window, &mut lpdw_process_id)
         };
 
         let active_window = ActiveWindow {


### PR DESCRIPTION
Hey,
I am not sure whether this was intentional or not but `process_id` for `ActiveWindow` was returning the thread id instead of process id on Windows.  For a downstream application I am building I needed to get the `process_id` of the window, so I went ahead and fixed it. Thought you may also be intrested in the fix :)