### PR TITLE
Get window owner's (application) name with kCGWindowOwnerName in case kCGWindowName fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,8 @@ dependencies = [
  "appkit-nsworkspace-bindings",
  "core-foundation",
  "core-graphics",
+ "objc-foundation",
+ "objc_id",
  "winapi",
  "xcb",
 ]
@@ -78,6 +80,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "cexpr"
@@ -292,6 +300,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ members = [
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.22"
 core-foundation = "0.9"
+objc-foundation = "0.1.1"
+objc_id = "0.1.1"
 appkit-nsworkspace-bindings = { path = "./appkit-nsworkspace-bindings", version = "0.1.0" }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/mac/platform_api.rs
+++ b/src/mac/platform_api.rs
@@ -82,6 +82,13 @@ impl PlatformApi for MacPlatformApi {
                     win_title = window_name;
                 }
 
+                if win_title.is_empty() {
+                    // Get the application's name if the window name wasn't set (common case in Quartz)
+                    if let DictEntryValue::_String(application_name) = get_from_dict(dic_ref, "kCGWindowOwnerName") {
+                        win_title = application_name;
+                    }
+                }
+
                 if let DictEntryValue::_Number(window_id) = get_from_dict(dic_ref, "kCGWindowNumber") {
                     let active_window = ActiveWindow {
                         window_id: window_id.to_string(),


### PR DESCRIPTION
Hey, so you might've noticed while testing kCGWindowName, that it doesn't provide the window's name for some applications.
I did some digging and apparently, it's a common thing in MacOS applications because they have to set this field directly in XQuartz for it to be available.

I fixed this problem by resulting to using the window owner's name when kCGWindowName fails.

A question that arises, since I'm exclusively on mac, is what is the actual `title` field referring to in your implementation on linux and windows. If it's referring to the application name rather than the window name, then you might just want to remove the use of kCGWindowName altogether.